### PR TITLE
Manually supply Avro schemas and directly access lat/long values.

### DIFF
--- a/generators/location-events/generator.json
+++ b/generators/location-events/generator.json
@@ -23,12 +23,12 @@
         "latitude": {
           "_gen": "var",
           "var": "location",
-          "selectKeys": ["latitude"]
+          "path": ["latitude"]
         },
         "longitude": {
           "_gen": "var",
           "var": "location",
-          "selectKeys": ["longitude"]
+          "path": ["longitude"]
         },
         "source_event_time": { "_gen": "now" }
       },
@@ -44,6 +44,19 @@
             "var": "location",
             "path": ["duration"]
           }
+        },
+        "kafkaKeyAvroSchemaHint": {
+          "type": "string"
+        },
+        "kafkaValueAvroSchemaHint": {
+          "type": "record",
+          "name": "locationEventsValue",
+          "fields": [
+            {"type": "string", "name": "device_serial"},
+            {"type": "double", "name": "latitude"},
+            {"type": "double", "name": "longitude"},
+            {"type": "long", "name": "source_event_time"}
+          ]
         }
       }
     }


### PR DESCRIPTION
This PR makes two changes:

1. Substitutes `path` for `selectKeys` on the lat/long values. The former directly accesses a nested value (`47.552646962878015`), the latter returns a subset of keys (`{"latitude": 47.552646962878015}`). I think you wanted the former.

2. Manually specifies the Avro schemas for the [key](https://docs.shadowtraffic.io/generator-configuration/kafkaKeyAvroSchemaHint/) and [value](https://docs.shadowtraffic.io/generator-configuration/kafkaValueAvroSchemaHint/).

A little more detail on (2): When ShadowTraffic tries to write to a topic with Schema Registry-enabled serializers, it tries to automatically create the schema for you and register it with SR. Sometimes this works fine. Sometimes it doesn't guess right. Sometimes it's just impossible for it to guess. In the case of accessing a variable and drilling into its field, it's very hard to statically figure out the right type.

To turn this behavior off, you can tell ShadowTraffic exactly what schemas you want to use for the key and value so there is no ambiguity, which is what those configuration parameters are about.